### PR TITLE
Add package.json type as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "oimophysics",
   "version": "1.2.2",
   "description": "A lightweight 3D physics engine.",
+  "type": "module",
   "main": "./bin/js_modules/OimoPhysics.js",
   "typings": "./bin/js_modules/OimoPhysics.d.ts",
   "scripts": {


### PR DESCRIPTION
For the ES6 import syntax to work from Node.js.

Without that an error is thrown from command-line:

```sh
import { oimo } from 'oimophysics';
         ^^^^
SyntaxError: Named export 'oimo' not found. The requested module 'oimophysics' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'oimophysics';
const { oimo } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:127:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:191:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12)

Node.js v17.4.0
```

For reference:
https://nodejs.org/docs/latest/api/esm.html#esm_enabling
