### PR TITLE
Add sleeping thresholds to RigidBody and RigidBodyConfig

### DIFF
--- a/demos/src/demo/js/minilib/ODrawMode.hx
+++ b/demos/src/demo/js/minilib/ODrawMode.hx
@@ -1,8 +1,7 @@
 package demo.js.minilib;
 import js.html.webgl.*;
 
-enum
-abstract ODrawMode(Int) to Int {
+enum abstract ODrawMode(Int) to Int {
 	var Points = GL.POINTS;
 	var Lines = GL.LINES;
 	var LineStrip = GL.LINE_STRIP;

--- a/demos/src/demo/js/minilib/ODrawMode.hx
+++ b/demos/src/demo/js/minilib/ODrawMode.hx
@@ -1,7 +1,7 @@
 package demo.js.minilib;
 import js.html.webgl.*;
 
-@:enum
+enum
 abstract ODrawMode(Int) to Int {
 	var Points = GL.POINTS;
 	var Lines = GL.LINES;

--- a/demos/src/demo/js/minilib/ODrawUsage.hx
+++ b/demos/src/demo/js/minilib/ODrawUsage.hx
@@ -1,7 +1,7 @@
 package demo.js.minilib;
 import js.html.webgl.*;
 
-@:enum
+enum
 abstract ODrawUsage(Int) to Int {
 	var StaticDraw = GL.STATIC_DRAW;
 	var DynamicDraw = GL.DYNAMIC_DRAW;

--- a/demos/src/demo/js/minilib/ODrawUsage.hx
+++ b/demos/src/demo/js/minilib/ODrawUsage.hx
@@ -1,8 +1,7 @@
 package demo.js.minilib;
 import js.html.webgl.*;
 
-enum
-abstract ODrawUsage(Int) to Int {
+enum abstract ODrawUsage(Int) to Int {
 	var StaticDraw = GL.STATIC_DRAW;
 	var DynamicDraw = GL.DYNAMIC_DRAW;
 }

--- a/demos/src/demo/js/minilib/OIndexBuffer.hx
+++ b/demos/src/demo/js/minilib/OIndexBuffer.hx
@@ -1,6 +1,7 @@
 package demo.js.minilib;
 import js.html.*;
 import js.html.webgl.*;
+import js.lib.Int16Array;
 
 class OIndexBuffer {
 	var gl:GL;

--- a/demos/src/demo/js/minilib/OVertexBuffer.hx
+++ b/demos/src/demo/js/minilib/OVertexBuffer.hx
@@ -1,6 +1,7 @@
 package demo.js.minilib;
 import js.html.*;
 import js.html.webgl.*;
+import js.lib.Float32Array;
 
 class OVertexBuffer {
 	public var numVertices(default, null):Int;

--- a/src/oimo/common/Setting.hx
+++ b/src/oimo/common/Setting.hx
@@ -64,7 +64,7 @@ class Setting {
 	public static var islandInitialRigidBodyArraySize:Int = 128;
 	public static var islandInitialConstraintArraySize:Int = 128;
 
-	// sleeping
+	// sleeping, some are just default values and can be changed through RigidBodyConfig
 	public static var sleepingVelocityThreshold:Float = 0.2;
 	public static var sleepingAngularVelocityThreshold:Float = 0.5;
 	public static var sleepingTimeThreshold:Float = 1.0;

--- a/src/oimo/dynamics/Island.hx
+++ b/src/oimo/dynamics/Island.hx
@@ -112,7 +112,7 @@ class Island {
 		// update sleep time
 		if (rb._isSleepy()) {
 			rb._sleepTime += dt;
-			if (rb._sleepTime > Setting.sleepingTimeThreshold) {
+			if (rb._sleepTime >= rb._sleepingTimeThreshold) {
 				rb.sleep();
 			}
 		} else {
@@ -172,7 +172,7 @@ class Island {
 			}
 
 			// check if the rigid body is awaken
-			if (rb._sleepTime < Setting.sleepingTimeThreshold) {
+			if (rb._sleepTime < rb._sleepingTimeThreshold) {
 				// awaken the whole island
 				sleepIsland = false;
 			}

--- a/src/oimo/dynamics/rigidbody/RigidBody.hx
+++ b/src/oimo/dynamics/rigidbody/RigidBody.hx
@@ -40,6 +40,8 @@ class RigidBody {
 	public var _sleepTime:Float;
 	public var _sleeping:Bool;
 	public var _autoSleep:Bool;
+	public var _sleepingVelocityThreshold:Float;
+	public var _sleepingAngularVelocityThreshold:Float;
 
 	public var _mass:Float;
 	public var _invMass:Float;
@@ -112,6 +114,8 @@ class RigidBody {
 		_sleepTime = 0;
 		_sleeping = false;
 		_autoSleep = config.autoSleep;
+		_sleepingVelocityThreshold = config.sleepingVelocityThreshold;
+		_sleepingAngularVelocityThreshold = config.sleepingAngularVelocityThreshold;
 
 		_mass = 0;
 		_invMass = 0;
@@ -209,8 +213,8 @@ class RigidBody {
 
 	extern public inline function _isSleepy():Bool {
 		return _autoSleep
-			&& M.vec3_dot(_vel, _vel) < Setting.sleepingVelocityThreshold * Setting.sleepingVelocityThreshold
-			&& M.vec3_dot(_angVel, _angVel) < Setting.sleepingAngularVelocityThreshold * Setting.sleepingAngularVelocityThreshold;
+			&& M.vec3_dot(_vel, _vel) < _sleepingVelocityThreshold * _sleepingVelocityThreshold
+			&& M.vec3_dot(_angVel, _angVel) < _sleepingAngularVelocityThreshold * _sleepingAngularVelocityThreshold;
 	}
 
 	extern public inline function _isAlone():Bool {

--- a/src/oimo/dynamics/rigidbody/RigidBody.hx
+++ b/src/oimo/dynamics/rigidbody/RigidBody.hx
@@ -42,6 +42,7 @@ class RigidBody {
 	public var _autoSleep:Bool;
 	public var _sleepingVelocityThreshold:Float;
 	public var _sleepingAngularVelocityThreshold:Float;
+	public var _sleepingTimeThreshold:Float;
 
 	public var _mass:Float;
 	public var _invMass:Float;
@@ -116,6 +117,7 @@ class RigidBody {
 		_autoSleep = config.autoSleep;
 		_sleepingVelocityThreshold = config.sleepingVelocityThreshold;
 		_sleepingAngularVelocityThreshold = config.sleepingAngularVelocityThreshold;
+		_sleepingTimeThreshold = config.sleepingTimeThreshold;
 
 		_mass = 0;
 		_invMass = 0;

--- a/src/oimo/dynamics/rigidbody/RigidBodyConfig.hx
+++ b/src/oimo/dynamics/rigidbody/RigidBodyConfig.hx
@@ -1,4 +1,6 @@
 package oimo.dynamics.rigidbody;
+
+import oimo.common.Setting;
 import oimo.common.Mat3;
 import oimo.common.Vec3;
 
@@ -64,7 +66,7 @@ class RigidBodyConfig {
 	/**
 	 * The time threshold to sleep the rigid body.
 	 */
-	 public var sleepingTimeThreshold:Float;
+	public var sleepingTimeThreshold:Float;
 
 	/**
 	 * Default constructor.
@@ -78,8 +80,9 @@ class RigidBodyConfig {
 		linearDamping = 0;
 		angularDamping = 0;
 		autoSleep = true;
-		sleepingVelocityThreshold = 0.2;
-		sleepingAngularVelocityThreshold = 0.5;
-		sleepingTimeThreshold = 1.0;
+		// inherit default value in Setting
+		sleepingVelocityThreshold = Setting.sleepingVelocityThreshold;
+		sleepingAngularVelocityThreshold = Setting.sleepingAngularVelocityThreshold;
+		sleepingTimeThreshold = Setting.sleepingTimeThreshold;
 	}
 }

--- a/src/oimo/dynamics/rigidbody/RigidBodyConfig.hx
+++ b/src/oimo/dynamics/rigidbody/RigidBodyConfig.hx
@@ -47,7 +47,7 @@ class RigidBodyConfig {
 
 	/**
 	 * Whether to automatically sleep the rigid body when it stops moving
-	 * for a certain period of time, namely `Setting.sleepingTimeThreshold`.
+	 * for a certain period of time, namely `sleepingTimeThreshold`.
 	 */
 	public var autoSleep:Bool;
 
@@ -60,6 +60,11 @@ class RigidBodyConfig {
 	 * The angular velocity threshold to sleep the rigid body.
 	 */
 	public var sleepingAngularVelocityThreshold:Float;
+
+	/**
+	 * The time threshold to sleep the rigid body.
+	 */
+	 public var sleepingTimeThreshold:Float;
 
 	/**
 	 * Default constructor.
@@ -75,5 +80,6 @@ class RigidBodyConfig {
 		autoSleep = true;
 		sleepingVelocityThreshold = 0.2;
 		sleepingAngularVelocityThreshold = 0.5;
+		sleepingTimeThreshold = 1.0;
 	}
 }

--- a/src/oimo/dynamics/rigidbody/RigidBodyConfig.hx
+++ b/src/oimo/dynamics/rigidbody/RigidBodyConfig.hx
@@ -34,12 +34,6 @@ class RigidBodyConfig {
 	public var type:Int;
 
 	/**
-	 * Whether to automatically sleep the rigid body when it stops moving
-	 * for a certain period of time, namely `Setting.sleepingTimeThreshold`.
-	 */
-	public var autoSleep:Bool;
-
-	/**
 	 * The damping coefficient of the linear velocity. Set positive values to
 	 * gradually reduce the linear velocity.
 	 */
@@ -52,6 +46,22 @@ class RigidBodyConfig {
 	public var angularDamping:Float;
 
 	/**
+	 * Whether to automatically sleep the rigid body when it stops moving
+	 * for a certain period of time, namely `Setting.sleepingTimeThreshold`.
+	 */
+	public var autoSleep:Bool;
+
+	/**
+	 * The linear velocity threshold to sleep the rigid body.
+	 */
+	public var sleepingVelocityThreshold:Float;
+
+	/**
+	 * The angular velocity threshold to sleep the rigid body.
+	 */
+	public var sleepingAngularVelocityThreshold:Float;
+
+	/**
 	 * Default constructor.
 	 */
 	public function new() {
@@ -60,8 +70,10 @@ class RigidBodyConfig {
 		linearVelocity = new Vec3();
 		angularVelocity = new Vec3();
 		type = RigidBodyType._DYNAMIC;
-		autoSleep = true;
 		linearDamping = 0;
 		angularDamping = 0;
+		autoSleep = true;
+		sleepingVelocityThreshold = 0.2;
+		sleepingAngularVelocityThreshold = 0.5;
 	}
 }

--- a/src/oimo/m/B.hx
+++ b/src/oimo/m/B.hx
@@ -185,7 +185,9 @@ class B {
 							type: macro:Float,
 							expr: null,
 							meta: null,
-							isFinal: false
+							isFinal: false,
+							isStatic: null,
+							namePos: null
 						};
 					}));
 				}

--- a/src/oimo/m/B.hx
+++ b/src/oimo/m/B.hx
@@ -12,6 +12,7 @@ using Lambda;
 /**
  * Build Macro
  */
+@:haxe.warning("-WDeprecated") // for using @:extern
 @:extern
 class B {
 


### PR DESCRIPTION
I have been using this library with [Armory3D](https://github.com/armory3d/armory/wiki). This helps initialize velocity thresholds from the [Blender](https://www.blender.org/)'s inspector instead of using the default values from [Setting](https://github.com/saharan/OimoPhysics/blob/master/src/oimo/common/Setting.hx).

Changes in this PR:
- Applied the fix from [this PR](https://github.com/saharan/OimoPhysics/pull/69#issue-2044722739).
- Updated the project to Haxe 4.3.4
- Added `sleepingVelocityThreshold` and `sleepingAngularVelocityThreshold` to `RigidBody.hx` and `RigidBodyConfig.hx`
- Added `sleepingTimeThreshold` to `RigidBodyConfig.hx` (this currently does nothing)